### PR TITLE
Fixed db encoding maxlength

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -14,6 +15,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+		Schema::defaultStringLength(191);
     }
 
     /**


### PR DESCRIPTION
При клоне не удается сделать migrate из - за ограничений на длину кодировки